### PR TITLE
Emit error rather than crash

### DIFF
--- a/tinytuya/__init__.py
+++ b/tinytuya/__init__.py
@@ -1551,6 +1551,9 @@ class BulbDevice(Device):
         if not status:
             return error_json(ERR_JSON,"state: empty response")
 
+        if 'Error' in status.keys():
+            return status
+
         for key in status[self.DPS].keys():
             if(key in self.DPS_2_STATE):
                 state[self.DPS_2_STATE[key]] = status[self.DPS][key]

--- a/tinytuya/wizard.py
+++ b/tinytuya/wizard.py
@@ -197,22 +197,12 @@ def wizard(color=True):
 
     # Get Oauth Token from tuyaPlatform
     uri = 'token?grant_type=1'
-    response_dict = tuyaPlatform(REGION, KEY, SECRET, uri)
-
-    if not response_dict['success']:
-        print('\n\n' + bold + 'Error from Tuya server: ' + dim + response_dict['msg'])
-        return
-
+    response_dict = tuyaPlatform(REGION, KEY, SECRET,uri)
     token = response_dict['result']['access_token']
 
     # Get UID from sample Device ID 
     uri = 'devices/%s' % DEVICEID
     response_dict = tuyaPlatform(REGION, KEY, SECRET, uri, token)
-
-    if not response_dict['success']:
-        print('\n\n' + bold + 'Error from Tuya server: ' + dim + response_dict['msg'])
-        return
-
     uid = response_dict['result']['uid']
 
     # Use UID to get list of all Devices for User

--- a/tinytuya/wizard.py
+++ b/tinytuya/wizard.py
@@ -197,12 +197,22 @@ def wizard(color=True):
 
     # Get Oauth Token from tuyaPlatform
     uri = 'token?grant_type=1'
-    response_dict = tuyaPlatform(REGION, KEY, SECRET,uri)
+    response_dict = tuyaPlatform(REGION, KEY, SECRET, uri)
+
+    if not response_dict['success']:
+        print('\n\n' + bold + 'Error from Tuya server: ' + dim + response_dict['msg'])
+        return
+
     token = response_dict['result']['access_token']
 
     # Get UID from sample Device ID 
     uri = 'devices/%s' % DEVICEID
     response_dict = tuyaPlatform(REGION, KEY, SECRET, uri, token)
+
+    if not response_dict['success']:
+        print('\n\n' + bold + 'Error from Tuya server: ' + dim + response_dict['msg'])
+        return
+
     uid = response_dict['result']['uid']
 
     # Use UID to get list of all Devices for User


### PR DESCRIPTION
In this instance, 'dps' is not a valid key in status, so the next line will crash.  For my device, at least, status is a well formed json error packet that matches the structure produced by error_json, so returning it seems reasonable.  My one caveat is that I can't get my device to work, so I can't be certain that a successful call will not also contain a key called Error.  If it does, you can change the code to test for the absence of 'dps'.